### PR TITLE
Remove CD32 mgl since MiSTer pack includes an mgl

### DIFF
--- a/mister/mgl/_Console/Amiga CDTV.mgl
+++ b/mister/mgl/_Console/Amiga CDTV.mgl
@@ -1,4 +1,4 @@
 <mistergamedescription>
     <rbf>_computer/minimig</rbf>
-    <setname>CDTV</setname>
+    <setname>AmigaCDTV</setname>
 </mistergamedescription>

--- a/mister/mgl/_Console/CD32.mgl
+++ b/mister/mgl/_Console/CD32.mgl
@@ -1,4 +1,0 @@
-<mistergamedescription>
-    <rbf>_computer/minimig</rbf>
-    <setname>CD32</setname>
-</mistergamedescription>


### PR DESCRIPTION
Updated the CDTV mgl naming to match the Amiga Vision and CD32 MiSTer packs